### PR TITLE
TypeError: Unicode-objects must be encoded before hashing

### DIFF
--- a/map4.py
+++ b/map4.py
@@ -108,7 +108,7 @@ class MAP4Calculator:
                     shingle_dict[shingle] += 1
                     shingle += '|' + str(shingle_dict[shingle])
 
-                atom_pairs.append(shingle)
+                atom_pairs.append(shingle.encode('utf-8'))
         return list(set(atom_pairs))
 
 


### PR DESCRIPTION
Hi, thanks for sharing the nice code!
I think string object should be encoded utf-8 before folded fingerprint calculation.
Thanks,

Taka / iwatobipen